### PR TITLE
Send Controller URL on Player connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "proxy": "http://localhost:3001",
   "dependencies": {
     "express": "^4.17.1",
+    "ip": "^1.1.5",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "react-router": "^5.1.2",

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,9 @@ const express = require("express");
 var app = express();
 var server = require("http").Server(app);
 var io = require("socket.io")(server);
+const ip = require("ip");
+
+const FRONTEND_PORT = 3000;
 
 server.listen(3001);
 
@@ -14,6 +17,7 @@ controllerNamespace.on("connection", socket => {
 
 displayNamespace.on("connection", socket => {
   console.log(`${new Date().toISOString()} - Display Connected`);
+  socket.emit('controllerUrl', `http://${ip.address()}${`:${FRONTEND_PORT}`}/controller`);
 });
 
 app.get("/bort", (req, res) => {


### PR DESCRIPTION
Fixes #8 

This is so mofos can turn on their kitchen thing and know where to go on their phone or whatever for the controller